### PR TITLE
Errors should be errors

### DIFF
--- a/common.lisp
+++ b/common.lisp
@@ -555,12 +555,12 @@ As a second value, return what RFC2388:PARSE-HEADER"
    :format-control "HTTP Internal Server Error"
    :status-code 500))
 
-(define-condition no-such-resource (http-condition) ()
+(define-condition no-such-resource (http-error) ()
   (:default-initargs
    :status-code 404
    :format-control "Resource does not exist"))
 
-(define-condition invalid-resource-arguments (http-condition) ()
+(define-condition invalid-resource-arguments (http-error) ()
   (:default-initargs
    :status-code 400
    :format-control "Resource exists but invalid arguments passed"))
@@ -607,7 +607,7 @@ As a second value, return what RFC2388:PARSE-HEADER"
    :status-code 501
    :format-control "Content type is not supported"))
 
-(define-condition no-such-route (http-condition) ()
+(define-condition no-such-route (http-error) ()
   (:default-initargs
    :format-control "Resource exists but no such route"))
 


### PR DESCRIPTION
The conditions `no-such-resource`, `no-such-route`, and `invalid-resource-arguments` are signaled with `error`, so they invoke the debugger, but are not subtypes of `error` (or even `serious-condition`), so they are not caught by handlers.

From the production standpoint, this is bad. If the debugger is disabled, this means the app dies on every 404. If the debugger is not disabled, it hangs on every 404.

Of course, one could explicitly handle `http-condition` signals, but that isn't documented anywhere and I think it would be much less surprising if all the error conditions were actually of type `error`.