### PR TITLE
Added make-clack-middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,12 @@ quickly let you jump into the action:
 (clack:clackup (snooze:make-clack-app) :port 9003)
 ```
 
+Snooze can also function as middleware for other clack apps:
+
+```lisp
+(clack:clackup (snooze:make-clack-middleware) ... (my-clack-app) :port 9003)
+```
+
 But Snooze doesn't "require" Clack or Hunchentoot in any sense. So if
 you want to use any other backend, I suggest you take a look at the
 implementations of `make-hunchentoot-app` and `make-clack-app`

--- a/api.lisp
+++ b/api.lisp
@@ -315,6 +315,17 @@ of special variables that affect Snooze, like *HOME-RESOURCE*,
     (read-sequence str (getf *clack-request-env* :raw-body))
     str))
 
+(defun make-clack-middleware (&optional bindings)
+  "Install Snooze in a Clack stack as middleware.
+
+A wrapper around make-clack-app that passes requests down the stack when a 404 is returned by Snooze."
+  (lambda (app)
+    (let ((snooze-app (make-clack-app bindings)))
+      (lambda (env)
+        (let ((results (funcall snooze-app env)))
+          (if (eq 404 (car results))
+              (funcall app env)
+              results))))))
 
 
 ;;; Direct hunchentoot integration

--- a/package.lisp
+++ b/package.lisp
@@ -101,6 +101,7 @@
    #:content-class-name
    #:*clack-request-env*
    #:make-clack-app
+   #:make-clack-middleware
    #:make-hunchentoot-app
    ;; default values for some options
    ;;


### PR DESCRIPTION
Using clack's :mount middleware to insert a snooze app in an existing
clack application doesn't work too well. Clack modifies the :path-info
field but snooze's make-clack-app reads from :request-uri. Fixing that
requires reassembling the URL from :path-info, :query-string, etc.

Adding make-clack-middleware is a simpler, cleaner solution.