### PR TITLE
Check for empty string case.

### DIFF
--- a/common.lisp
+++ b/common.lisp
@@ -932,16 +932,18 @@ EXPLAIN-CONDITION.")
 ;;;
 (defun default-resource-name (uri)
   "Default value for *RESOURCE-NAME-FUNCTION*, which see."
-  (let* ((first-slash-or-qmark (position-if #'(lambda (char)
-                                                (member char '(#\/ #\?)))
-                                            uri
-                                            :start 1)))
-    (values (cond (first-slash-or-qmark
-                   (subseq uri 1 first-slash-or-qmark))
-                  (t
-                   (subseq uri 1)))
-            (if first-slash-or-qmark
-                (subseq uri first-slash-or-qmark)))))
+  (if (string= "" uri)
+    ""
+    (let* ((first-slash-or-qmark (position-if #'(lambda (char)
+                                                  (member char '(#\/ #\?)))
+                                              uri
+                                              :start 1)))
+      (values (cond (first-slash-or-qmark
+                     (subseq uri 1 first-slash-or-qmark))
+                    (t
+                     (subseq uri 1)))
+              (if first-slash-or-qmark
+                  (subseq uri first-slash-or-qmark))))))
 
 (defun search-for-extension-content-type (uri-path)
   "Default value for *URI-CONTENT-TYPES-FUNCTION*, which see."
@@ -1069,11 +1071,3 @@ EXPLAIN-CONDITION.")
              (not (symbol-package object)))
         (princ-to-string (string-downcase (symbol-name object)))
         (write-to-string object))))
-
-
-
-
-
-
-
-


### PR DESCRIPTION
After updating quicklisp and sbcl recently, I've discovered that I need to add this bit of code.  The empty string will cause a subseq error later in the function ... essentially (subseq "" 1)

I don't know if this is because snooze changed, hunchtoot changed, sbcl changed, or ???  But it's a reasonable patch, IMO.
