### PR TITLE
Fix defresource, defroute to handle lambda var correctly.

### DIFF
--- a/common.lisp
+++ b/common.lisp
@@ -238,10 +238,11 @@
         (t
          (list type-spec t))))
 
-(defun ensure-atom (thing)
-  (if (listp thing)
-      (ensure-atom (first thing))
-      thing))
+(defun ensure-gf-lambda-var (thing)
+  (etypecase thing
+    (atom thing)
+    ((cons symbol) (car thing))
+    ((cons cons) thing)))
 
 (defun ensure-uri (maybe-uri)
   (etypecase maybe-uri
@@ -465,7 +466,7 @@ As a second value, return what RFC2388:PARSE-HEADER"
          (proper-lambda-list
            `(,verb-spec ,type-spec ,@(nthcdr 2 lambda-list)))
          (simplified-lambda-list
-           (mapcar #'ensure-atom proper-lambda-list)))
+           (mapcar #'ensure-gf-lambda-var proper-lambda-list)))
     `(progn
        (unless (find-resource ',name)
          (defresource ,name ,simplified-lambda-list))
@@ -512,7 +513,7 @@ As a second value, return what RFC2388:PARSE-HEADER"
                  else
                    collect option))
          (simplified-lambda-list (mapcar #'(lambda (argspec)
-                                             (ensure-atom argspec))
+                                             (ensure-gf-lambda-var argspec))
                                          lambda-list)))
     `(progn
        ,@(if genpath-form `(,genpath-form))

--- a/package.lisp
+++ b/package.lisp
@@ -1,7 +1,7 @@
 (defpackage #:snooze-common
   (:use #:cl)
   (:export
-   #:ensure-atom
+   #:ensure-gf-lambda-var
    #:content-type-spec-or-lose
    #:verb-spec-or-lose
    #:parse-defroute-args


### PR DESCRIPTION
Don't ensure-atom. When the form ((:keyword-name var)) comes,
an error is signaled due to keyword symbol could not use as variable.

* common.lisp (defroute-1 defresource-1): Using ensure-gf-lambda-var
(ensure-atom): Delete, no longer needed.
(ensure-gf-lambda-var): New function.

* package.lisp (#:snooze-common): Export ensure-gf-lambda-var
(#:snooze-common): Don't export ensure-atom

FYI [clhs generic function lambda list](http://www.lispworks.com/documentation/HyperSpec/Body/03_db.htm)

Minimum error form is `(defresource name (verb type &key ((:keyword-name var))))`