### PR TITLE
make-clack-app: add dynamically bound clack-response-headers plist

### DIFF
--- a/api.lisp
+++ b/api.lisp
@@ -274,6 +274,7 @@ BACKEND defaults to *BACKEND*"
 ;;; Clack integration
 ;;;
 (defvar *clack-request-env*)
+(defvar *clack-response-headers*)
 
 (setf (documentation '*clack-request-env* 'variable)
       "Bound in function made by MAKE-CLACK-APP to Clack environment.")
@@ -285,7 +286,8 @@ Pass this to CLACK:CLACKUP.
 
 Dynamically binds *CLACK-REQUEST-ENV* around every call to
 HANDLE-REQUEST so you can access the backend-specific from routes
-and/or EXPLAIN-CONDITION. Also binds *BACKEND* to :CLACK.
+and/or EXPLAIN-CONDITION. Dynamically binds *CLACK-RESPONSE-HEADERS*
+in order to set response headers. Binds *BACKEND* to :CLACK.
 
 BINDINGS is an alist of (SYMBOL . VALUE) which is are also
 dynamically-bound around HANDLE-REQUEST. You can use it to pass values
@@ -293,6 +295,7 @@ of special variables that affect Snooze, like *HOME-RESOURCE*,
 *RESOURCES-FUNCTION*, *RESOURCE-NAME-FUNCTION*, or
 *URI-CONTENT-TYPES-FUNCTION*."
   (lambda (env) (let ((*clack-request-env* env)
+                      (*clack-response-headers* nil)
                       (*backend* :clack))
                   (progv
                       (mapcar #'car bindings)
@@ -306,7 +309,7 @@ of special variables that affect Snooze, like *HOME-RESOURCE*,
                                      by #'cddr
                                      when v collect k and collect v))
                       `(,status-code
-                        (:content-type ,payload-ct)
+                        (:content-type ,payload-ct ,@*clack-response-headers*)
                         (,payload)))))))
 
 (defmethod backend-payload ((backend (eql :clack)) (type snooze-types:text))


### PR DESCRIPTION
This pull request makes it so users can add response headers to clack apps

The documented `redirect-to` function looks like below:

```lisp
(defun redirect-to (url &optional
                          (format-control "Redirected")
                          format-args)
  (setf (hunchentoot:header-out :location) url)
  (snooze:http-condition 303
                         (format nil "~?" format-control format-args)))
```

If you're using hunchentoot, this is fine, but if you're using clack with something other than hunchentoot (such as [woo](https://github.com/fukamachi/woo)) it doesn't work since hunchentoot isn't being used

This allows the `redirect-to` function to look like this:

```lisp
(defun redirect-to (url &optional (format-control "Redirected") format-args))
    (setf (getf *clack-response-headers* :location) url)
    (http-condition 302 (format nil "~?" format-control format-args)))
```
